### PR TITLE
ci: fix cyclonedx-py --output-file flag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Generate CycloneDX 1.6 SBOM
         run: |
           pip install -e .
-          cyclonedx-py environment --output-format JSON --spec-version 1.6 --outfile sbom.json
+          cyclonedx-py environment --output-format JSON --spec-version 1.6 --output-file sbom.json
 
       - name: Attach artifacts to release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
The v0.9.6 tag release run failed at 'Generate CycloneDX 1.6 SBOM': newer cyclonedx-bom renamed `--outfile` to `--output-file`, so `dist/*` + `sbom.json` never attached to the release. One-line flag fix; exact command verified locally (CycloneDX 1.6, 73 components). After merge the v0.9.6 tag will be re-pointed to pick up the fixed workflow and complete the release assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)